### PR TITLE
Reorder -maxdepth and -mindepth position

### DIFF
--- a/sd
+++ b/sd
@@ -30,7 +30,7 @@ __sd_directory_help() {
   no_commands=true
   # this loop is incredibly slow. on zsh we can do a glob instead of a find, and
   # it's noticeably faster.
-  for file in $(find "$target" -not -name '.*' -maxdepth 1 -mindepth 1 -exec test -x {} \; -print); do
+  for file in $(find "$target" -maxdepth 1 -mindepth 1 -not -name '.*' -exec test -x {} \; -print); do
     command=$(basename "$file")
     helpfile="$file.help"
     if [[ -f "$helpfile" ]]; then


### PR DESCRIPTION
Just address the following `find` warning, as running `sd --help`
produced the following output with warnings:

❯ sd --help
sd commands

find: warning: you have specified the global option -maxdepth after the argument -not, but global options are not positional, i.e., -maxdepth affects tests specified before it as well as those specified after it.  Please specify global options before other arguments.
find: warning: you have specified the global option -mindepth after the argument -not, but global options are not positional, i.e., -mindepth affects tests specified before it as well as those specified after it.  Please specify global options before other arguments.
test ...   -- test commands
