### PR TITLE
Fish completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,9 +295,7 @@ plugins+=(sd)
 source "$ZSH/oh-my-zsh.sh"
 ```
 
-# bash/fish autocompletion support
-
-Patrick Jackson contributed [an unofficial fish completion script](https://gist.github.com/patricksjackson/5065e4a9d8e825dafc7824112f17a5e6), which should be usable with some modification (as written it does not respect `SD_ROOT`, but it should act as a very good starting point if you use fish).
+# bash autocompletion support
 
 Bash doesn't support the fancy completion-with-description feature that is sort of the whole point of `sd`, but there are apparently ways to hack something similar.
 

--- a/README.md
+++ b/README.md
@@ -247,13 +247,14 @@ As far as I know, [Nix](https://search.nixos.org/packages?channel=unstable&query
 ## Without a package manager
 
 1. Put the `sd` script somewhere on your `PATH`.
-2. Put the `_sd` completion script somewhere on your `fpath`.
+2. For zsh completions, put the `_sd` completion script somewhere on your `fpath`.
+3. For fish completions, put the `sd.fish` completion script into your [completions directory](https://fishshell.com/docs/current/completions.html#where-to-put-completions), probably `~/.config/fish/completions/`.
 
 I like to symlink `sd` to `~/bin`, which is already on my path. If you've cloned this repo to `~/src/sd`, you can do that by running something like:
 
     $ ln -s ~/src/sd/sd ~/bin/sd
 
-There isn't really a standard place in your home directory to put completion scripts, so unless you've made your own, you'll probably want to add your clone directly to your `fpath`. You should add that to your `.zshrc` file before the line where you call `compinit`. It should look something like this:
+With zsh, there isn't really a standard place in your home directory to put completion scripts, so unless you've made your own, you'll probably want to add your clone directly to your `fpath`. You should add that to your `.zshrc` file before the line where you call `compinit`. It should look something like this:
 
     # ~/.zshrc
 

--- a/sd.fish
+++ b/sd.fish
@@ -1,0 +1,106 @@
+# Completions for the custom Script Directory (sd) script
+
+# These are based on the contents of the Script Directory, so we're reading info from the files.
+# The description is taken either from the first line of the file $cmd.help,
+# or the first non-shebang comment in the $cmd file.
+
+# Also note, completions are loaded at fish startup, not dynamically, so you need to reload fish for changes here to take effect.
+
+# Shell completions are arcane wizardry, so hopefully you don't need to touch this very often.
+
+# The '-f' on all complete commands is to disable file completions everywhere except for after the full command is written out
+
+# Create command completions for a subcommand
+# Takes a list of all the subcommands seen so far
+function __list_subcommand
+    # Handles fully nested subcommands
+    set basepath (string join '/' "$SD_ROOT" $argv)
+
+    # Total subcommands
+    # Used so that we can ignore duplicate commands
+    set -l commands
+    for file in (ls -d $basepath/*)
+        set cmd (basename $file .help)
+        set helpfile $cmd.help
+        if [ (basename $file) != "$helpfile" ]
+            set commands $commands $cmd
+        end
+    end
+
+    # Setup the check for when to show these commands
+    # Basically you need to have seen everything in the path up to this point but not any commands in the current directory.
+    # This will cause problems if you have a command with the same name as a directory parent.
+    set check
+    for arg in $argv
+        set check (string join ' and ' $check "__fish_seen_subcommand_from $arg;")
+    end
+    set check (string join ' ' $check "and not __fish_seen_subcommand_from $commands")
+
+    # Loop through the files using their full path names.
+    for file in (ls -d $basepath/*)
+        set cmd (basename $file .help)
+        set helpfile $cmd.help
+        if [ (basename $file) = "$helpfile" ]
+            # This is the helpfile, use it for the help statement
+            set help (head -n1 "$file")
+            complete -f -c sd -a "$cmd" -d "$help" \
+                -n $check
+        else if test -d "$file"
+            set help "$cmd commands"
+            __list_subcommand $argv $cmd
+            complete -f -c sd -a "$cmd" -d "$help" \
+                -n "$check"
+        else
+            set help (sed -nE -e '/^#!/d' -e '/^#/{s/^# *//; p; q;}' "$file")
+            if not test -e "$helpfile"
+                complete -f -c sd -a "$cmd" -d "$help" \
+                    -n "$check"
+            end
+        end
+    end
+end
+
+function __list_commands
+    # commands is used in the completions to know if we've seen the base commands
+    set -l commands
+
+    # Create a list of commands for this directory.
+    # The list is used to know when to not show more commands from this directory.
+    for file in $argv
+        set cmd (basename $file .help)
+        set helpfile $cmd.help
+        if [ (basename $file) != "$helpfile" ]
+            # Ignore the special commands that take the paths as input.
+            if not contains $cmd cat edit help new which
+                set commands $commands $cmd
+            end
+        end
+    end
+    for file in $argv
+        set cmd (basename $file .help)
+        set helpfile $cmd.help
+        if [ (basename $file) = "$helpfile" ]
+            # This is the helpfile, use it for the help statement
+            set help (head -n1 "$file")
+            complete -f -c sd -a "$cmd" -d "$help" \
+                -n "not __fish_seen_subcommand_from $commands"
+        else if test -d "$file"
+            # Directory, start recursing into subcommands
+            set help "$cmd commands"
+            __list_subcommand $cmd
+            complete -f -c sd -a "$cmd" -d "$help" \
+                -n "not __fish_seen_subcommand_from $commands"
+        else
+            # Script
+            # Pull the help test from the first non-shebang commented line.
+            set help (sed -nE -e '/^#!/d' -e '/^#/{s/^# *//; p; q;}' "$file")
+            if not test -e "$helpfile"
+                complete -f -c sd -a "$cmd" -d "$help" \
+                    -n "not __fish_seen_subcommand_from $commands"
+            end
+        end
+    end
+end
+
+# Hardcode the starting directory
+__list_commands "$SD_ROOT"/*

--- a/sd.fish
+++ b/sd.fish
@@ -6,8 +6,6 @@
 
 # Also note, completions are loaded at fish startup, not dynamically, so you need to reload fish for changes here to take effect.
 
-# Shell completions are arcane wizardry, so hopefully you don't need to touch this very often.
-
 # The '-f' on all complete commands is to disable file completions everywhere except for after the full command is written out
 
 # Create command completions for a subcommand


### PR DESCRIPTION
Opening this as a PR, and removing the link to the fish shell completions gist (the link was broken anyways after I renamed my account). If you don't want the completions merged, I can remove the completions script and just update the docs for the correct link.

The fish shell completions now respect SD_ROOT and should work fine. I've used this daily since I wrote it 1.5 years ago, and have never needed to fix anything. Note that this also works for completing the special commands `cat edit help new which`, which the zsh completions don't handle.

I will update home-manager, and the docs for that, myself if you want to merge this.

