### PR TITLE
docs: Nix now installs zsh completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,15 +232,6 @@ As far as I know, [Nix](https://search.nixos.org/packages?channel=unstable&query
       };
     };
   };
-  
-  home.programs.zsh = {
-    # The script-directory module doesn't automatically configure
-    # zsh completion, so we still have manually add this:
-  
-    initExtra = ''
-    fpath+="${pkgs.script-directory}/share/zsh/site-functions"
-    '';
-  };
 }
 ```
 


### PR DESCRIPTION
Removing the Nix instructions to manually install the zsh completions.

The Nix package now installs zsh shell completions correctly, AFAICT: https://github.com/NixOS/nixpkgs/blob/9cc3b66a15941549ba883e7d85b678c6a7f9f8ae/pkgs/tools/misc/script-directory/default.nix#L29

If it doesn't work for you without this, maybe it is still necessary on some setups. I have only tested on NixOS.